### PR TITLE
blender 4.0 support

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -477,9 +477,11 @@ class EggMaterial:
         bsdf.inputs["Metallic"].default_value = bmat.metallic
         if self.ior is not None:
             bsdf.inputs["IOR"].default_value = self.ior
-        bsdf.inputs["Emission"].default_value = self.emit
+        emission_key = "Emission" if bpy.app.version < (4, 0) else "Emission Color"
+        bsdf.inputs[emission_key].default_value = self.emit
         if not any(self.spec[:3]):
-            bsdf.inputs["Specular"].default_value = 0.0
+            specular_key = "Specular" if bpy.app.version < (4, 0) else "Specular IOR Level"
+            bsdf.inputs[specular_key].default_value = 0.0
 
         color_out = bsdf.inputs['Base Color']
         alpha_out = bsdf.inputs['Alpha']


### PR DESCRIPTION
Blender 4 has replaced the field Emission with two fields Emission Color and Emission Strength, as well as the field Specular with two fields Specular Tint and Specular IOR Level. This pull request adds the support for these fields.

Note that I am not sure that Specular IOR Level is the correct replacement for Specular. However, as long as models with complex materials aren't imported, it works.