### PR TITLE
Properties: Join collide values

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -1299,7 +1299,11 @@ class EggGroup(EggGroupNode):
                 self.blend_color[3] = parse_number(values[0])
 
         elif type == 'COLLIDE':
-            self.properties[orig_type] = values[0]
+            # Collide tags will often consist of several words,
+            # i.e. "Polyset descend", "Polyset keep descend"
+            # If we don't join values, then we only get the
+            # first value in the array, "Polyset"
+            self.properties[orig_type] = ' '.join(values)
 
         elif type == 'OBJECTTYPE':
             # It's not uncommon to have more than one ObjectType on an object


### PR DESCRIPTION
Egg Collide values will often be more than one word, for example "Polyset keep descend", but the importer currently only assigns value[0]. That means that the tag as it is imported to Blender will end up being "Polyset". Joining the values fixes this.