### PR TITLE
Importer: Add version check for auto smoothing

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -1546,7 +1546,8 @@ class EggGroup(EggGroupNode):
 
                 if max_diff > 0.01:
                     data.normals_split_custom_set(self.normals)
-                    data.use_auto_smooth = True
+                    if bpy.app.version <= (4, 0):
+                        data.use_auto_smooth = True
 
             if self.have_vertex_colors:
                 cols = data.vertex_colors.new()


### PR DESCRIPTION
`use_auto_smooth` was removed in 4.1. Didn't have any trouble importing various .eggs into 4.2 with this fix.