### PR TITLE
Preferences: Add backup texture path preference & Principled BSDF preference

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -30,6 +30,16 @@ from bpy import props
 from bpy_extras.io_utils import ImportHelper
 
 
+class EggImporterPreferences(bpy.types.AddonPreferences):
+    bl_idname = __name__
+
+    backup_texpath: props.StringProperty(name="Texture path", subtype="FILE_PATH")
+
+    def draw(self, context):
+        layout = self.layout
+        layout.prop(self, "backup_texpath")
+
+
 class IMPORT_OT_egg(bpy.types.Operator, ImportHelper):
     """Import .egg Operator"""
     bl_idname = "import_scene.egg"
@@ -141,10 +151,12 @@ def make_annotations(cls):
             delattr(cls, k)
     return cls
 
+classes = (IMPORT_OT_egg, EggImporterPreferences)
 
 def register():
     make_annotations(IMPORT_OT_egg)
-    bpy.utils.register_class(IMPORT_OT_egg)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
     if bpy.app.version >= (2, 80):
         bpy.types.TOPBAR_MT_file_import.append(menu_func)
@@ -158,7 +170,8 @@ def unregister():
     else:
         bpy.types.INFO_MT_file_import.remove(menu_func)
 
-    bpy.utils.unregister_class(IMPORT_OT_egg)
+    for cls in classes:
+        bpy.utils.unregister_class(cls)
 
 
 if __name__ == "__main__":

--- a/__init__.py
+++ b/__init__.py
@@ -33,11 +33,37 @@ from bpy_extras.io_utils import ImportHelper
 class EggImporterPreferences(bpy.types.AddonPreferences):
     bl_idname = __name__
 
-    backup_texpath: props.StringProperty(name="Texture path", subtype="FILE_PATH")
+    if bpy.app.version >= (2, 80):
+        backup_texpath: props.StringProperty(
+            name = "Texture path",
+            subtype = "FILE_PATH",
+            description = "Backup texture path to check if the texture can't be "
+                          "found at the location of the .egg"
+        )
+        want_bsdf: props.BoolProperty(
+            name = "Use Principled BSDF",
+            default = True,
+            description = "Determines whether materials will automatically use Principled BSDF. "
+                          "If false, they won't have shading"
+        )
+    else:
+        backup_texpath = props.StringProperty(
+            name="Texture path",
+            subtype="FILE_PATH",
+            description="Backup texture path to check if the texture can't be "
+                        "found at the location of the .egg"
+        )
+        want_bsdf = props.BoolProperty(
+            name="Use Principled BSDF",
+            default=True,
+            description="Determines whether materials will automatically use Principled BSDF. "
+                        "If false, they won't have shading"
+        )
 
     def draw(self, context):
         layout = self.layout
         layout.prop(self, "backup_texpath")
+        layout.prop(self, "want_bsdf")
 
 
 class IMPORT_OT_egg(bpy.types.Operator, ImportHelper):

--- a/importer.py
+++ b/importer.py
@@ -198,7 +198,7 @@ class EggContext:
         else:
             try:
                 # If the user has set a backup texture path in preferences, we should check there.
-                backup_path = bpy.context.preferences.addons[__name__.split('.')[0]].preferences.backup_texpath
+                backup_path = bpy.context.preferences.addons[__package__].preferences.backup_texpath
                 if backup_path and os.path.exists(os.path.join(backup_path, path)):
                     image = bpy.data.images.load(os.path.join(backup_path, path))
                 else:

--- a/importer.py
+++ b/importer.py
@@ -198,7 +198,7 @@ class EggContext:
         else:
             try:
                 # If the user has set a backup texture path in preferences, we should check there.
-                backup_path = bpy.context.preferences.addons['blender-egg-importer-master'].preferences.backup_texpath
+                backup_path = bpy.context.preferences.addons[__name__.split('.')[0]].preferences.backup_texpath
                 if backup_path and os.path.exists(os.path.join(backup_path, path)):
                     image = bpy.data.images.load(os.path.join(backup_path, path))
                 else:

--- a/importer.py
+++ b/importer.py
@@ -196,9 +196,14 @@ class EggContext:
             image = bpy.data.images.load(path)
             #image.filepath = path
         else:
-            # Try loading it with the original path, just in case.
             try:
-                image = bpy.data.images.load(path)
+                # If the user has set a backup texture path in preferences, we should check there.
+                backup_path = bpy.context.preferences.addons['blender-egg-importer-master'].preferences.backup_texpath
+                if backup_path and os.path.exists(os.path.join(backup_path, path)):
+                    image = bpy.data.images.load(os.path.join(backup_path, path))
+                else:
+                    # Try loading it with the original path, just in case.
+                    image = bpy.data.images.load(path)
             except RuntimeError:
                 # That failed, of course.  OK, create a new image with this
                 # filename, and issue an error.


### PR DESCRIPTION
The texture path preference is helpful in cases where the texture path in a .egg is relative, but not to its current location. Saves time usually spent forcing Blender to find missing textures. Could be expanded in the future to hold several paths to check (akin to Panda3D's model-paths).

The Principled BSDF preference exists because some games made using Panda3D do not use shaders, and the importer defaulting to Principled BSDF for materials makes some egg files not be the same visually in Blender as they are in their egg files. Though possible to manually remove the BSDF node from materials when importing, this is something that has saved me a lot of time.