### PR TITLE
Importer: Add version check for mipmap usage

### DIFF
--- a/importer.py
+++ b/importer.py
@@ -863,7 +863,7 @@ class EggTexture:
                     self.texture.use_normal_map = True
                     self.texture.image.colorspace_settings.name = 'Non-Color'
 
-            elif name == 'minfilter':
+            elif name == 'minfilter' and bpy.app.version <= (2, 80):
                 self.minfilter = values[0].lower()
                 if 'mipmap' in self.minfilter:
                     self.texture.use_mipmap = True


### PR DESCRIPTION
`use_mipmap` was removed in 5.0, although it hasn't done anything since 2.8. This makes the importer work without error in versions 5.0 (tested on 5.1).